### PR TITLE
Add Nix flake dev environment and CI integration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Run tests inside dev shell
+        run: |
+          nix develop .# --command bash -c "make check-mira && make test"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,101 +1,58 @@
 # Installing Miranda
 
-This project requires the Miranda programming language interpreter. Follow the instructions below to install Miranda on your system.
+This project now provides a reproducible Nix development environment that builds
+the Miranda interpreter directly from source. The flake ensures the
+`mira` binary and its standard library are available for the Makefile targets
+and tests in this repository.
 
-## Prerequisites
+## Recommended: Use the Nix Flake
 
-- C compiler (gcc or clang)
-- make
-- UNIX-like system (Linux, macOS, WSL)
+1. [Install Nix](https://nixos.org/download.html) if you don't already have it.
+2. (Optional but convenient) enable
+   [`direnv`](https://direnv.net/) with [nix-direnv](https://github.com/nix-community/nix-direnv)
+   so the environment is loaded automatically.
+3. Allow the flake for this repository:
 
-## Installation Steps
+   ```bash
+   direnv allow   # if using direnv
+   # or start a shell manually
+   nix develop
+   ```
 
-### Option 1: Download from Official Site (Recommended)
+The first activation will compile Miranda from source using the pinned
+configuration in `flake.nix`. Afterwards, the `mira` command is on your `PATH`
+and exported via the `MIRA` variable so that `make run`, `make demo`, and
+`make test` work without any additional setup.
 
-1. Visit the official Miranda homepage: http://miranda.org.uk/
-2. Download the latest Miranda source code from the downloads section
-3. Extract the archive to a directory of your choice
+## Alternative: Manual Installation
 
-### Option 2: Clone from Repository
+If you cannot use Nix, follow the upstream instructions to build Miranda
+manually:
 
-```bash
-# Clone the open source Miranda implementation
-git clone https://codeberg.org/miranda-ng/miranda.git
-cd miranda
-```
+1. Clone the open-source implementation:
 
-### Building Miranda
+   ```bash
+   git clone https://github.com/ncihnegn/miranda
+   cd miranda
+   ```
 
-1. Navigate to the Miranda source directory
-2. Clean any existing build artifacts:
+2. Build the interpreter:
+
    ```bash
    make cleanup
-   ```
-
-3. Build Miranda:
-   ```bash
    make
-   ```
-
-4. Test the installation:
-   ```bash
    ./mira
    ```
 
-### Adding Miranda to PATH (Optional)
+3. Add the resulting directory to your `PATH` or symlink `mira` into a
+   location that is already on your `PATH`.
 
-To use Miranda from anywhere, add it to your PATH:
-
-```bash
-# Add to your ~/.bashrc, ~/.zshrc, or equivalent
-export PATH="/path/to/miranda:$PATH"
-```
-
-Or create a symlink:
-```bash
-sudo ln -s /path/to/miranda/mira /usr/local/bin/mira
-```
-
-## Usage
-
-### Running Miranda Scripts
-
-```bash
-# Run a Miranda script
-mira script.m
-
-# Interactive mode
-mira
-```
-
-### Example Session
-
-```miranda
-mira> 2 + 3
-5
-mira> let double x = x * 2
-mira> double 5
-10
-mira> /q
-```
-
-## Project Usage
-
-Once Miranda is installed, you can run the exercises:
+Once Miranda is installed you can run the project exercises:
 
 ```bash
 cd src
 mira main.m
 ```
 
-## Troubleshooting
-
-- If you encounter build errors, check that you have a C11/C18 compatible compiler
-- On macOS, you may need to install Xcode command line tools: `xcode-select --install`
-- On Ubuntu/Debian, install build essentials: `sudo apt-get install build-essential`
-
-## References
-
-- Miranda homepage: http://miranda.org.uk/
-- GitHub mirror: https://github.com/ncihnegn/miranda
-- Documentation: https://github.com/garrett-may/miranda-documentation
+For additional troubleshooting tips, consult the upstream Miranda
+documentation at https://github.com/ncihnegn/miranda.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-V3nDbPw+5JUmsFMVKxAVDrm7042j/maA0sE2Hk32WYM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758427187,
+        "narHash": "sha256-nI056mykwuI9zhnDugtNrK6fbvsU4D7b2bxsIpLtH9g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,94 @@
+{
+  description = "Development environment for Introduction to Functional Programming using Miranda";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+
+        miranda = pkgs.stdenv.mkDerivation {
+          pname = "miranda";
+          version = "unstable-2025-05-25";
+
+          src = pkgs.fetchFromGitHub {
+            owner = "ncihnegn";
+            repo = "miranda";
+            rev = "21206e7dab13afd681b6f16d2482a5e8180223bb";
+            sha256 = "sha256-LbJk5qd7yRp60z+us1UH67Ft1hPgo1pmCcmYyMCWm4o=";
+          };
+
+          nativeBuildInputs = [
+            pkgs.byacc
+            pkgs.makeWrapper
+          ];
+
+          dontConfigure = true;
+
+          buildPhase = ''
+            runHook preBuild
+            make $makeFlags
+            runHook postBuild
+          '';
+
+          postPatch = ''
+            substituteInPlace Makefile \
+              --replace '`git show -s --format=%cd --date=format:'\''%d %b %Y'\''`' '$(BUILD_DATE)'
+          '';
+
+          makeFlags = [
+            ''BUILD_DATE="25 May 2025"''
+          ];
+
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p "$out/bin"
+            mkdir -p "$out/lib/miralib"
+            mkdir -p "$out/share/man/man1"
+
+            cp mira "$out/bin/"
+            cp -r miralib/. "$out/lib/miralib/"
+            cp mira.1 "$out/share/man/man1/"
+
+            wrapProgram "$out/bin/mira" \
+              --set MIRALIB "$out/lib/miralib"
+
+            runHook postInstall
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Miranda functional programming language implementation";
+            homepage = "https://github.com/ncihnegn/miranda";
+            license = licenses.gpl2;
+            maintainers = [];
+            platforms = platforms.unix;
+          };
+        };
+      in
+      {
+        packages = {
+          default = miranda;
+          inherit miranda;
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = [
+            miranda
+            pkgs.gnumake
+            pkgs.git
+          ];
+
+          shellHook = ''
+            export MIRA=${miranda}/bin/mira
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary
- package the Miranda interpreter from source in a flake-powered development shell
- document how to enter the flake (and keep manual instructions as a fallback)
- exercise the Makefile targets from within the flake in GitHub Actions

## Testing
- `make check-mira`
- `make test` *(fails: Miranda reports an OFFSIDE syntax error in tests/test_runner.m)*

------
https://chatgpt.com/codex/tasks/task_b_68d2cf9a4f408332b5db1f5cac90b2fd