### PR TITLE
Switch Miranda source from GitHub mirror to official Codeberg repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ make check
 ### Miranda Language
 - [Official Miranda Homepage](http://miranda.org.uk/)
 - [Miranda Documentation](https://github.com/garrett-may/miranda-documentation)
-- [Open Source Implementation](https://github.com/ncihnegn/miranda)
+- [Open Source Implementation](https://codeberg.org/DATurner/miranda)
 
 ### Book Reference
 - **Title:** Introduction to Functional Programming

--- a/flake.nix
+++ b/flake.nix
@@ -20,13 +20,11 @@
 
           miranda = pkgs.stdenv.mkDerivation {
             pname = "miranda";
-            version = "unstable-2025-05-25";
+            version = "2.067";
 
-            src = pkgs.fetchFromGitHub {
-              owner = "ncihnegn";
-              repo = "miranda";
-              rev = "21206e7dab13afd681b6f16d2482a5e8180223bb";
-              sha256 = "sha256-UjEDFif5oA9SzfKgeZ9R+0bOHRAoVphCIoDCsFBUDJA=";
+            src = pkgs.fetchurl {
+              url = "https://codeberg.org/DATurner/miranda/archive/miranda-2.067.tar.gz";
+              sha256 = "sha256-8geE3+Y61gC9UoP79kN/blY+amJJn8wIG38ab/gQiF4=";
             };
 
             nativeBuildInputs = [
@@ -73,7 +71,7 @@
 
             meta = with pkgs.lib; {
               description = "Miranda functional programming language implementation";
-              homepage = "https://github.com/ncihnegn/miranda";
+              homepage = "https://codeberg.org/DATurner/miranda";
               license = licenses.gpl2;
               maintainers = [];
               platforms = platforms.unix;

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,7 @@
 
             postPatch = ''
               substituteInPlace Makefile \
+                --replace "CC = clang" "CC ?= clang" \
                 --replace "\`git show -s --format=%cd --date=format:'%d %b %Y'\`" '$(BUILD_DATE)' \
                 --replace '$(CC) -v 2>> .host' '$(CC) -v 2>> .host || true'
             '';


### PR DESCRIPTION
- Update source from ncihnegn/miranda GitHub mirror to official DATurner/miranda on Codeberg
- Upgrade to official release version 2.067 (June 11, 2025) from unstable snapshot
- Switch from fetchFromGitHub to fetchurl using official release tarball
- Update homepage metadata to point to authoritative Codeberg repository
- Includes bug fixes, performance improvements, and better platform support