### PR TITLE
Organize tests by chapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,19 @@ run: check-mira
 
 test: check-mira
 	@echo "Running tests..."
-	@if [ -f "$(TESTS_DIR)/test_runner.m" ]; then \
-		cd $(TESTS_DIR) && $(MIRA) test_runner.m; \
-	else \
-		echo "No tests available yet. Run 'make run'."; \
+	@set -e; \
+	found=0; \
+	for runner in $(TESTS_DIR)/chapter*/test_runner.m; do \
+	        if [ -f "$$runner" ]; then \
+	                found=1; \
+	                chapter_dir=$$(dirname "$$runner"); \
+	                chapter_name=$${chapter_dir##$(TESTS_DIR)/}; \
+	                echo "Running $$chapter_name tests..."; \
+	                (cd "$$chapter_dir" && $(MIRA) test_runner.m); \
+	        fi; \
+	done; \
+	if [ $$found -eq 0 ]; then \
+	        echo "No tests available yet. Run 'make run'."; \
 	fi
 
 check: run

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ This project attempts to transform exercise solutions into a proper Miranda code
 │   ├── chapter01/
 │   │   └── exercises.m     # Chapter 1 solutions
 │   └── main.m             # Main entry point
-├── tests/                 # Test suites
-│   ├── test_runner.m      # Main test runner
+├── tests/                 # Test suites organized by chapter
+│   ├── chapter01/
+│   │   └── test_runner.m  # Chapter 1 tests
 │   └── validate.sh        # Project validation script
 ├── INSTALL.md             # Miranda installation guide
 ├── Makefile              # Build automation
@@ -57,7 +58,7 @@ make
 # Run main program with all exercises
 make run
 
-# Run test suite
+# Run test suite (executes each chapter's tests)
 make test
 ```
 
@@ -111,7 +112,7 @@ make check
 
 3. **Add tests:**
    ```miranda
-   # In tests/test_runner.m
+   # In tests/chapterNN/test_runner.m
    test_function_cases = [
        test_eq expected (function_name input) "description"
    ]

--- a/tests/chapter01/test_runner.m
+++ b/tests/chapter01/test_runner.m
@@ -1,7 +1,7 @@
 || Test Runner for Introduction to Functional Programming Solutions
 || Basic testing framework for Miranda functions
 
-%include "../src/chapter01/exercises.m"
+%include "../../src/chapter01/exercises.m"
 
 || Test assertions and utilities
 
@@ -61,7 +61,7 @@ count_failed = total_tests - count_passed
 
 || Test summary
 test_summary = ["",
-                "=== TEST SUMMARY ===",
+                "=== CHAPTER 1 TEST SUMMARY ===",
                 "Total tests: " ++ show total_tests,
                 "Passed: " ++ show count_passed,
                 "Failed: " ++ show count_failed,

--- a/tests/validate.sh
+++ b/tests/validate.sh
@@ -39,16 +39,28 @@ if command -v mira &> /dev/null; then
     fi
     cd ..
 
-    # Test test runner compilation
-    echo "Testing test runner..."
+    # Test chapter test runner compilation
+    echo "Testing chapter test runners..."
     cd tests
-    if echo "" | mira test_runner.m &> /dev/null; then
-        echo "✓ Test runner compiles successfully"
-    else
-        echo "✗ Test runner compilation failed"
-        echo "Running mira test_runner.m for detailed error output:"
-        mira test_runner.m
-        exit 1
+    chapter_found=0
+    for runner in chapter*/test_runner.m; do
+        if [ -f "$runner" ]; then
+            chapter_found=1
+            chapter_dir=$(dirname "$runner")
+            chapter_name=$(basename "$chapter_dir")
+            echo "Testing $chapter_name..."
+            if echo "" | mira "$runner" &> /dev/null; then
+                echo "✓ $chapter_name test runner compiles successfully"
+            else
+                echo "✗ $chapter_name test runner compilation failed"
+                echo "Running mira $runner for detailed error output:"
+                mira "$runner"
+                exit 1
+            fi
+        fi
+    done
+    if [ $chapter_found -eq 0 ]; then
+        echo "No chapter test runners found."
     fi
     cd ..
 


### PR DESCRIPTION
## Summary
- move the chapter 1 tests into a dedicated chapter directory and fix the runner metadata
- update the Makefile test target to execute each chapter-specific test runner
- refresh the validation script and README to reflect the new chapter-oriented test layout

## Testing
- ./tests/validate.sh

------
https://chatgpt.com/codex/tasks/task_b_68d5781c4c5c833280f225b2807e761b